### PR TITLE
Incognito same window setting exclusivity

### DIFF
--- a/page.js
+++ b/page.js
@@ -67,6 +67,7 @@ var StoredData = {
         settingId: "openTabsInIncognito",
         onStartup: function() {
             var field = document.getElementById(this.settingId);
+            if (StoredData.openTabsSameWindow.value) this.set(false); // If openTabsSameWindow, force openTabsInIncognito to false.
             field.checked = this.value; // Set the default
             field.addEventListener('change', () => {
                 this.set(field.checked);
@@ -150,7 +151,7 @@ var StoredData = {
         "openToolNewWindow",
         "openTabsSameWindow",
         "saveUrlList",
-        "openTabsInIncognito",
+        "openTabsInIncognito", // Must come after openTabsSameWindow, as it's value from load may be trumped by openTabsSameWindow.
         "showPauseButton",
         "storedUrlList",
         "showSettings",

--- a/page.js
+++ b/page.js
@@ -39,6 +39,10 @@ var StoredData = {
 
             field.addEventListener('change', () => {
                 this.set(field.checked);
+                if (field.checked) { // openTabsSameWindow & openTabsInIncognito should be mutually exclusive.
+                    document.getElementById(StoredData.openTabsInIncognito.settingId).checked = false;
+                    StoredData.openTabsInIncognito.set(false);
+                }
             });
         },
     },
@@ -64,7 +68,13 @@ var StoredData = {
         onStartup: function() {
             var field = document.getElementById(this.settingId);
             field.checked = this.value; // Set the default
-            field.addEventListener('change', () => { this.set(field.checked); });
+            field.addEventListener('change', () => {
+                this.set(field.checked);
+                if (field.checked) { // openTabsSameWindow & openTabsInIncognito should be mutually exclusive.
+                    document.getElementById(StoredData.openTabsSameWindow.settingId).checked = false;
+                    StoredData.openTabsSameWindow.set(false);
+                }
+            });
         },
     },
     showPauseButton: { /* SETTING: Should the pause button be shown, or hidden? */

--- a/page.js
+++ b/page.js
@@ -37,12 +37,8 @@ var StoredData = {
             var field = document.getElementById(this.settingId);
             field.checked = this.value; // Set the default
 
-            var dependentField = document.getElementById("openTabsInIncognito");
-            dependentField.disabled = field.checked;
-
             field.addEventListener('change', () => {
                 this.set(field.checked);
-                dependentField.disabled = field.checked;
             });
         },
     },


### PR DESCRIPTION
A review from the Chrome Web Store made me think that the behavior of disabling the incognito checkbox when the same-window checkbox is checked isn't clear to users. An unchecked and _disabled_ checkbox does not look very visually different from an unchecked _enabled_ checkbox, which is what users see with default settings.

So, instead of disabling the incognito checkbox, it would be better to simply make these two settings turn the other off when checked. This means new users can simply check the incognito checkbox, and it will check successfully, as well as uncheck the same-window checkbox, teaching the user that these two settings must be mutually exclusive.