### PR TITLE
Setting delete loaded tabs at end

### DIFF
--- a/page.html
+++ b/page.html
@@ -42,6 +42,7 @@
                 <p style="display: flex;"><input type="checkbox" id="openToolNewWindow">Open this tool in new window.</p>
                 <p style="display: flex;"><input type="checkbox" id="openTabsSameWindow">Open tabs in same window as tool.</p>
                 <p style="display: flex;"><input type="checkbox" id="openTabsInIncognito">Open tabs in incognito.</p>
+                <p style="display: flex;"><input type="checkbox" id="closeTabsOnAllComplete">Once all tabs are loaded, close them.</p>
             </div>
         </div>
 

--- a/page.js
+++ b/page.js
@@ -334,6 +334,7 @@ function openTabWhenPriorIsLoaded(index) {
                 console.log("All urls have been loaded fully");
                 chrome.tabs.onUpdated.removeListener(thisListener);
                 chrome.tabs.onRemoved.removeListener(thisListener);
+                if (StoredData.closeTabsOnAllComplete.value) { chrome.tabs.remove(allOpenedTabIds); }
                 openButton.enable();
                 if (StoredData.closeOnComplete.value) { window.close(); }
                 return;

--- a/page.js
+++ b/page.js
@@ -265,7 +265,10 @@ https://www.google.com/search?q=shirt
 https://www.google.com/search?q=pants
 `.trim();
 var urlList = undefined;
+var allOpenedTabIds = undefined;
 async function openUrls() {
+    allOpenedTabIds = [];
+
     urlList = getUrls();
     urlList = urlList.length > 0 ? urlList : getUrls(exampleUrls); // Use the example urls if text is empty.
     tabTitleCounter.reset();
@@ -289,6 +292,7 @@ async function openUrls() {
             .then((result) => {
                 // Begin opening rest of urls.
                 priorTabId = result.tabs[0].id;
+                allOpenedTabIds.push(priorTabId);
                 windowId = result.id;
                 tabTitleCounter.iterate();
                 openTabWhenPriorIsLoaded(1);
@@ -301,6 +305,7 @@ async function openUrls() {
             .then((result) => {
                 // Begin opening rest of urls.
                 priorTabId = result.id;
+                allOpenedTabIds.push(priorTabId);
                 windowId = undefined;
                 tabTitleCounter.iterate();
                 openTabWhenPriorIsLoaded(1);
@@ -332,6 +337,7 @@ function openTabWhenPriorIsLoaded(index) {
             .then(function(result) {
                 // Prepare for the newly created tab to load, hense creating another tab.
                 priorTabId = result.id;
+                allOpenedTabIds.push(priorTabId);
                 tabTitleCounter.iterate();
                 openTabWhenPriorIsLoaded(++index);
                 chrome.tabs.onUpdated.removeListener(thisListener);

--- a/page.js
+++ b/page.js
@@ -312,15 +312,17 @@ async function openUrls() {
 var windowId = undefined;
 var priorTabId = undefined;
 function openTabWhenPriorIsLoaded(index) {
-    if (index >= urlList.length) { // Stop once urlList is fully iterated.
-        console.log("All urls have been opened");
-        openButton.enable();
-        if (StoredData.closeOnComplete.value) { window.close(); }
-        return;
-    }
-
     const thisListener = (tabId, info) => {
         if (tabId === priorTabId && (info.status === "complete" || info.isWindowClosing !== undefined)) {
+            if (index >= urlList.length) { // Stop once urlList is fully iterated (AND LOADED).
+                console.log("All urls have been loaded fully");
+                chrome.tabs.onUpdated.removeListener(thisListener);
+                chrome.tabs.onRemoved.removeListener(thisListener);
+                openButton.enable();
+                if (StoredData.closeOnComplete.value) { window.close(); }
+                return;
+            }
+
             // The tab has loaded or been closed. Time to make another.
             const createTab = () => chrome.tabs.create({
                 "url": urlList[index],

--- a/page.js
+++ b/page.js
@@ -146,6 +146,16 @@ var StoredData = {
     //         theTextArea.value = this.value ?? theTextArea.value;
     //     },
     // },
+    closeTabsOnAllComplete: { /* SETTING: (Special behavior) Once all the tabs have been loaded, should they all be closed? */
+        value: (localStorage.getItem("closeTabsOnAllComplete") ?? "false") === "true",
+        set: function(newVal) { this.value = newVal, localStorage.setItem("closeTabsOnAllComplete", newVal); },
+        settingId: "closeTabsOnAllComplete",
+        onStartup: function() {
+            var field = document.getElementById(this.settingId);
+            field.checked = this.value; // Set the default
+            field.addEventListener('change', () => this.set(field.checked));
+        },
+    },
     _startupOrder: [
         "closeOnComplete",
         "openToolNewWindow",
@@ -155,6 +165,7 @@ var StoredData = {
         "showPauseButton",
         "storedUrlList",
         "showSettings",
+        "closeTabsOnAllComplete",
     ],
 };
 


### PR DESCRIPTION
A review on the Chrome Web Store suggested this feature: a setting to auto-delete the tabs once they've loaded.

This implementation assumes that the desired behavior of this feature is to delete the tabs once _all_ tabs have been loaded fully, instead of tabs being deleted immediately upon loading.