### PR TITLE
Stop UI from flickering on startup.

### DIFF
--- a/page.html
+++ b/page.html
@@ -7,7 +7,9 @@
     <title>Sequential Mass URL Opener</title>
 </head>
 <body>
-    <div class="container" style="text-align: center; max-width: 769px; margin: auto;">
+    <style> .hide-until-ui-stable { visibility: hidden; } </style>
+
+    <div class="hide-until-ui-stable" style="text-align: center; max-width: 769px; margin: auto;">
         <div><p>
             This tool will open a list of urls into a window. Each tab will be 
             opened once the prior tab has been loaded fully. As opposed to other 

--- a/page.js
+++ b/page.js
@@ -231,6 +231,9 @@ pauseButton.onclick = () => {
     pauseState.toggle();
 };
 
+document.styleSheets[0].cssRules[0].style.visibility = "unset"; /* Many elements have been changing during startup, 
+and so are hidden. Now that they are stable, unhide them. */
+
 
 
 function getUrls(testingText) {


### PR DESCRIPTION
Visual elements are moved around and style-changed during startup, which causes a short but jarring flicker. This change will hide elements in flux at startup (currently all elements are being included because it's easy), until these UI changes have stopped.