### PR TITLE
Grab the selected text on selection triggers, and show the number of …

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Sequential Mass URL Opener",
   "description": "Opens each URL in list into tabs in a window, but only if prior pages have finished loading.",
-  "version": "2.4",
+  "version": "2.5",
   "manifest_version": 3,
   "action": {
     "default_icon": "icon.png",

--- a/page.html
+++ b/page.html
@@ -62,6 +62,9 @@
                 <p style="display: flex;"><input type="checkbox" id="openTabsInIncognito">Open tabs in incognito.</p>
                 <p style="display: flex;"><input type="checkbox" id="closeTabsOnAllComplete">Once all tabs are loaded, close them.</p>
                 <p style="display: flex;"><input type="checkbox" id="closeEachTabOnComplete">Once a tab is loaded, close it.</p>
+                <p style="display: flex; margin-bottom: 0; justify-content: right; filter: opacity(0.6);">
+                    <span id="lines-selected-number-span"></span>&nbsp;lines selected
+                </p>
             </div>
         </div>
 

--- a/page.js
+++ b/page.js
@@ -274,6 +274,27 @@ for (key of StoredData._startupOrder) {
 
 
 
+const linesSelectedDisplayer = {
+    displayerElement: document.getElementById("lines-selected-number-span"),
+    line_count: "",
+    onStartup: function() {
+        theTextArea.addEventListener("select", () => {
+            this.line_count = window.getSelection().toString().split(/\r|\r\n|\n/).length;
+            this.render();
+        });
+        theTextArea.addEventListener("focusout", () => {
+            this.line_count = "";
+            this.render();
+        });
+        
+        this.render();
+    },
+    render: function() {
+        this.displayerElement.innerText = this.line_count;
+    },
+};
+linesSelectedDisplayer.onStartup();
+
 const tabTitleCounter = {
     loaded: 0,
     total: 0,


### PR DESCRIPTION
…lines selected.

Also wipe it when the textarea is unfocused, as nothing should be selected.